### PR TITLE
feat: cleaned up bolt_vars for non ec2 use

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Sidekick is a [sidecar](https://learn.microsoft.com/en-us/azure/architecture/pat
 
 ## Running Sidekick
 
+### Env Variables
+
+In order to run sidekick, you first need to set some ENV variables
+
+```bash
+export BOLT_CUSTOM_DOMAIN=<YOUR_CUSTOM_DOMAIN>
+# Optional if not running on a ec2 instance or running in a different region
+export AWS_REGION=<YOUR_BOLT_CLUSTER_REGION>
+# Optional if not running on a ec2 instance to force read from a read-replica in this az 
+export AWS_ZONE_ID=<AWS_ZONE_ID> 
+```
+
 ### Local
 
 You can run sidekick directly from the command line:
@@ -40,7 +52,7 @@ docker build -t sidekick .
 running:
 
 ```bash
-docker run -p 7075:7075 --env BOLT_CUSTOM_DOMAIN=<YOUR_CUSTOM_DOMAIN> sidekick serve
+docker run -p 7075:7075 --env BOLT_CUSTOM_DOMAIN=<YOUR_CUSTOM_DOMAIN> -env AWS_REGION=<YOUR_BOLT_CLUSTER_REGION> sidekick serve
 ```
 
 ## Using Sidekick

--- a/boltrouter/bolt_endpoints_test.go
+++ b/boltrouter/bolt_endpoints_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetBoltEndpoints(t *testing.T) {
 	ctx := context.Background()
 	logger := zaptest.NewLogger(t)
-	SetupQuickSilverMock(t, logger)
+	SetupQuickSilverMock(t, ctx, logger)
 
 	testCases := []struct {
 		name     string
@@ -38,7 +38,7 @@ func TestGetBoltEndpoints(t *testing.T) {
 func TestSelectBoltEndpoint(t *testing.T) {
 	ctx := context.Background()
 	logger := zaptest.NewLogger(t)
-	SetupQuickSilverMock(t, logger)
+	SetupQuickSilverMock(t, ctx, logger)
 
 	testCases := []struct {
 		name       string

--- a/boltrouter/bolt_request_test.go
+++ b/boltrouter/bolt_request_test.go
@@ -12,7 +12,7 @@ import (
 func TestBoltRequest(t *testing.T) {
 	ctx := context.Background()
 	logger := zaptest.NewLogger(t)
-	SetupQuickSilverMock(t, logger)
+	SetupQuickSilverMock(t, ctx, logger)
 
 	testCases := []struct {
 		name       string

--- a/boltrouter/bolt_router.go
+++ b/boltrouter/bolt_router.go
@@ -24,7 +24,7 @@ type BoltRouter struct {
 
 // NewBoltRouter creates a new BoltRouter.
 func NewBoltRouter(ctx context.Context, logger *zap.Logger, cfg Config) (*BoltRouter, error) {
-	boltVars, err := GetBoltVars(logger)
+	boltVars, err := GetBoltVars(ctx, logger)
 	if err != nil {
 		return nil, fmt.Errorf("could not get BoltVars: %w", err)
 	}

--- a/boltrouter/main_test.go
+++ b/boltrouter/main_test.go
@@ -1,6 +1,7 @@
 package boltrouter
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -46,9 +47,9 @@ func QuicksilverMock(t *testing.T) *httptest.Server {
 	return server
 }
 
-func SetupQuickSilverMock(t *testing.T, logger *zap.Logger) {
+func SetupQuickSilverMock(t *testing.T, ctx context.Context, logger *zap.Logger) {
 	quicksilver := QuicksilverMock(t)
-	boltVars, err := GetBoltVars(logger)
+	boltVars, err := GetBoltVars(ctx, logger)
 	require.NoError(t, err)
 	boltVars.QuicksilverURL.Set(quicksilver.URL)
 }


### PR DESCRIPTION
cleans up the bolt_vars.go to be easier to use in non ec2 instances