### PR TITLE
feat: refresh AWS credentials periodically

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,7 +34,7 @@ func New(ctx context.Context, logger *zap.Logger, cfg Config) (*Api, error) {
 	}
 	// Refresh endpoints periodically
 	br.RefreshEndpointsPeriodically(ctx)
-	br.RefreshAWSCredentialsPeriodically(ctx)
+	br.RefreshAWSCredentialsPeriodically(ctx, logger)
 
 	return &Api{
 		logger: logger,

--- a/api/api.go
+++ b/api/api.go
@@ -34,6 +34,7 @@ func New(ctx context.Context, logger *zap.Logger, cfg Config) (*Api, error) {
 	}
 	// Refresh endpoints periodically
 	br.RefreshEndpointsPeriodically(ctx)
+	br.RefreshAWSCredentialsPeriodically(ctx)
 
 	return &Api{
 		logger: logger,

--- a/boltrouter/aws_credentials_client.go
+++ b/boltrouter/aws_credentials_client.go
@@ -19,10 +19,8 @@ var refreshRoutineScheduled bool = false
 // GetAwsCredentialsFromRegion returns the aws credentials for the given region.
 func getAwsCredentialsFromRegion(ctx context.Context, region string) (aws.Credentials, error) {
 	if awsCred, ok := awsCredentialsMap.Load(region); ok {
-		fmt.Printf("returning existing credentials for region %s\n", region)
 		return awsCred.(aws.Credentials), nil
 	}
-	fmt.Printf("creating new credentials for region %s\n", region)
 	return newAwsCredentialsFromRegion(ctx, region)
 }
 
@@ -49,10 +47,7 @@ func (br *BoltRouter) RefreshAWSCredentials(ctx context.Context) error {
 		region := key.(string)
 		cred := value.(aws.Credentials)
 
-		fmt.Printf("Considering refresh for %v\n", region)
-
 		if cred.CanExpire {
-			fmt.Printf("credentials can expire, region %s\n", region)
 			// if credential can expire, get new credentials for the region
 			refreshedCreds, err := newAwsCredentialsFromRegion(ctx, region)
 			if err != nil {

--- a/boltrouter/aws_credentials_client.go
+++ b/boltrouter/aws_credentials_client.go
@@ -14,7 +14,6 @@ import (
 
 // awsCredentialsMap is used to cache aws credentials for a given region.
 var awsCredentialsMap = sync.Map{}
-var refreshRoutineScheduled bool = false
 
 // GetAwsCredentialsFromRegion returns the aws credentials for the given region.
 func getAwsCredentialsFromRegion(ctx context.Context, region string) (aws.Credentials, error) {

--- a/boltrouter/aws_credentials_client.go
+++ b/boltrouter/aws_credentials_client.go
@@ -45,11 +45,11 @@ func newAwsCredentialsFromRegion(ctx context.Context, region string) (aws.Creden
 func (br *BoltRouter) RefreshAWSCredentials(ctx context.Context) error {
 	var errs []error
 
-	fmt.Println("refreshing aws credentials\n")
-
 	awsCredentialsMap.Range(func(key, value interface{}) bool {
 		region := key.(string)
 		cred := value.(aws.Credentials)
+
+		fmt.Printf("Considering refresh for %v\n", region)
 
 		if cred.CanExpire {
 			fmt.Printf("credentials can expire, region %s\n", region)
@@ -85,7 +85,6 @@ func (br *BoltRouter) RefreshAWSCredentialsPeriodically(ctx context.Context) {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				fmt.Println("getting new credentialsssssss")
 				br.RefreshAWSCredentials(ctx)
 			}
 		}

--- a/boltrouter/aws_credentials_client.go
+++ b/boltrouter/aws_credentials_client.go
@@ -38,7 +38,7 @@ func newAwsCredentialsFromRegion(ctx context.Context, region string) (aws.Creden
 	return cred, nil
 }
 
-func (br *BoltRouter) RefreshAWSCredentials(ctx context.Context, logger *zap.Logger) {
+func refreshAWSCredentials(ctx context.Context, logger *zap.Logger) {
 
 	awsCredentialsMap.Range(func(key, value interface{}) bool {
 		region := key.(string)
@@ -67,7 +67,7 @@ func (br *BoltRouter) RefreshAWSCredentialsPeriodically(ctx context.Context, log
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				br.RefreshAWSCredentials(ctx, logger)
+				refreshAWSCredentials(ctx, logger)
 			}
 		}
 	}()

--- a/boltrouter/aws_credentials_client.go
+++ b/boltrouter/aws_credentials_client.go
@@ -70,7 +70,7 @@ func (br *BoltRouter) RefreshAWSCredentials(ctx context.Context) error {
 }
 
 func (br *BoltRouter) RefreshAWSCredentialsPeriodically(ctx context.Context) {
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(30 * time.Minute)
 
 	go func() {
 		for {

--- a/boltrouter/bolt_router.go
+++ b/boltrouter/bolt_router.go
@@ -75,7 +75,7 @@ func (br *BoltRouter) refreshAWSCredentials(ctx context.Context) error {
 }
 
 func (br *BoltRouter) refreshAWSCredentialsPeriodically(ctx context.Context) {
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(30 * time.Minute)
 
 	for {
 		select {

--- a/boltrouter/bolt_router.go
+++ b/boltrouter/bolt_router.go
@@ -48,41 +48,5 @@ func NewBoltRouter(ctx context.Context, logger *zap.Logger, cfg Config) (*BoltRo
 		boltVars:           boltVars,
 	}
 
-	if err := br.refreshAWSCredentials(ctx); err != nil {
-		return nil, err
-	}
-
-	if br.awsCred.CanExpire {
-		go br.refreshAWSCredentialsPeriodically(ctx)
-	}
-
 	return br, nil
-}
-
-func (br *BoltRouter) refreshAWSCredentials(ctx context.Context) error {
-	awsCfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		return fmt.Errorf("could not load aws default config: %w", err)
-	}
-
-	cred, err := awsCfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		return fmt.Errorf("could not retrieve aws credentials: %w", err)
-	}
-
-	br.awsCred = cred
-	return nil
-}
-
-func (br *BoltRouter) refreshAWSCredentialsPeriodically(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Minute)
-
-	for {
-		select {
-		case <-ctx.Done():
-			ticker.Stop()
-		case <-ticker.C:
-			br.refreshAWSCredentials(ctx)
-		}
-	}
 }

--- a/boltrouter/bolt_router.go
+++ b/boltrouter/bolt_router.go
@@ -64,8 +64,6 @@ func (br *BoltRouter) refreshAWSCredentials(ctx context.Context) error {
 	}
 
 	cred, err := awsCfg.Credentials.Retrieve(ctx)
-	fmt.Printf("Credential can expire %v\n", cred.CanExpire)
-	fmt.Printf("Credential expires at %v\n", cred.Expires)
 	if err != nil {
 		return fmt.Errorf("could not retrieve aws credentials: %w", err)
 	}

--- a/boltrouter/bolt_router.go
+++ b/boltrouter/bolt_router.go
@@ -52,7 +52,9 @@ func NewBoltRouter(ctx context.Context, logger *zap.Logger, cfg Config) (*BoltRo
 		return nil, err
 	}
 
-	go br.refreshAWSCredentialsPeriodically(ctx)
+	if br.awsCred.CanExpire {
+		go br.refreshAWSCredentialsPeriodically(ctx)
+	}
 
 	return br, nil
 }


### PR DESCRIPTION
Refresh AWS credentials in Bolt router every 30 minutes since on EC2 the temporary credentials have a 1 hour expiration.