### PR TITLE
feat: allow boltrouter config to be set from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ export AWS_REGION=<YOUR_BOLT_CLUSTER_REGION>
 export AWS_ZONE_ID=<AWS_ZONE_ID>
 ```
 
+### Failover 
+
+Sidekick automatically failovers the request to s3 if the bolt request fails. For example This is usefull when the object does not exist in bolt yet.
+You can disable failover by passing a flag or setting a ENV variable:
+
+```bash
+# Using flag
+go run main serve --failover=false
+# Using binary
+./sidekick serve --failover=false
+```
+
+```bash
+# Using env variable
+export SIDEKICK_BOLTROUTER_FAILOVER=true
+go run main serve
+```
+
 ### Local
 
 You can run sidekick directly from the command line:

--- a/boltrouter/config.go
+++ b/boltrouter/config.go
@@ -3,11 +3,11 @@ package boltrouter
 type Config struct {
 	// If set, boltrouter will be running in local mode.
 	// For example, boultrouter will not query quicksilver to get endpoints.
-	Local bool
+	Local bool `yaml:"Local"`
 
 	// Enable pass through in Bolt.
-	Passthrough bool
+	Passthrough bool `yaml:"Passthrough"`
 
 	// Enable failover to a aws request if the Bolt request fails.
-	Failover bool
+	Failover bool `yaml:"Failover"`
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/project-n-oss/sidekick/boltrouter"
+)
+
+type Config struct {
+	BoltRouter boltrouter.Config `yaml:"BoltRouter"`
+}
+
+const configPrefix = "SIDEKICK"
+
+// UnmarshalConfigFromEnv populates config with values from environment variables. The names of the
+// environment variables read are formed by joining the config struct's field names with underscores
+// and adding a "SIDEKICK" prefix. For example, if you want to set the Redis address, you would use
+// SIDEKICK_BOLTROUTER_FAILOVER=true
+func UnmarshalConfigFromEnv(ctx context.Context, config *Config) error {
+	_, err := unmarshalConfig(configPrefix, reflect.ValueOf(config), func(key string) (*string, error) {
+		v, ok := os.LookupEnv(key)
+		if !ok {
+			return nil, nil
+		}
+		return &v, nil
+	})
+	return err
+}
+
+func unmarshalConfig(prefix string, v reflect.Value, lookup func(string) (*string, error)) (didUnmarshal bool, err error) {
+	if v.Kind() == reflect.Ptr && !v.IsNil() {
+		if env, err := lookup(prefix); err != nil {
+			return false, err
+		} else if env != nil {
+			switch dest := v.Interface().(type) {
+			case *bool:
+				switch *env {
+				case "false":
+					*dest = false
+				case "true":
+					*dest = true
+				default:
+					return false, fmt.Errorf("boolean config must be \"true\" or \"false\"")
+				}
+			case *int:
+				n, err := strconv.Atoi(*env)
+				if err != nil {
+					return false, fmt.Errorf("invalid value for integer config")
+				}
+				*dest = n
+			case *string:
+				*dest = *env
+			case *[]byte:
+				buf, err := base64.StdEncoding.DecodeString(*env)
+				if err != nil {
+					return false, fmt.Errorf("byte slice configs must be base64 encoded")
+				}
+				*dest = buf
+			case *[]int:
+				parts := strings.Split(*env, ",")
+				intParts := make([]int, len(parts))
+				for i, part := range parts {
+					intParts[i], err = strconv.Atoi(strings.TrimSpace(part))
+					if err != nil {
+						return false, fmt.Errorf("invalid value for integer config")
+					}
+				}
+				*dest = intParts
+			case *[]string:
+				parts := strings.Split(*env, ",")
+				for i, part := range parts {
+					parts[i] = strings.TrimSpace(part)
+				}
+				*dest = parts
+			default:
+				return false, fmt.Errorf("unsupported environment config type %T", v.Elem().Interface())
+			}
+			return true, nil
+		}
+	}
+
+	if v.Kind() == reflect.Ptr {
+		if !v.IsNil() {
+			return unmarshalConfig(prefix, v.Elem(), lookup)
+		}
+
+		new := reflect.New(v.Type().Elem())
+		didUnmarshal, err := unmarshalConfig(prefix, new, lookup)
+		if err != nil {
+			return false, err
+		} else if didUnmarshal {
+			v.Set(new)
+		}
+		return didUnmarshal, nil
+	}
+
+	if v.Kind() == reflect.Struct {
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			didUnmarshalField, err := unmarshalConfig(prefix+"_"+strings.ToUpper(t.Field(i).Name), v.Field(i).Addr(), lookup)
+			if err != nil {
+				return false, err
+			}
+			if didUnmarshalField {
+				didUnmarshal = true
+			}
+		}
+	}
+
+	return didUnmarshal, nil
+}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/project-n-oss/sidekick/boltrouter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalConfig(t *testing.T) {
+	for name, tc := range map[string]struct {
+		Environment map[string]string
+		In          Config
+		Expected    *Config
+	}{
+		"EnvOnly": {
+			Environment: map[string]string{
+				"TEST_BOLTROUTER_FAILOVER": "true",
+			},
+			Expected: &Config{
+				BoltRouter: boltrouter.Config{
+					Failover: true,
+				},
+			},
+		},
+		"Override": {
+			Environment: map[string]string{
+				"TEST_BOLTROUTER_FAILOVER": "false",
+			},
+			In: Config{
+				BoltRouter: boltrouter.Config{
+					Failover: true,
+				},
+			},
+			Expected: &Config{
+				BoltRouter: boltrouter.Config{
+					Failover: false,
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := tc.In
+			_, err := unmarshalConfig("TEST", reflect.ValueOf(&config), func(key string) (*string, error) {
+				if v, ok := tc.Environment[key]; ok {
+					return &v, nil
+				}
+				return nil, nil
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Expected, &config)
+		})
+	}
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testServeCmd = &cobra.Command{
+	Use: "test",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+}
+
+func TestServeCmdConfig(t *testing.T) {
+	initServerFlags(testServeCmd)
+	rootCmd.AddCommand(testServeCmd)
+
+	t.Run("Default", func(t *testing.T) {
+		rootCmd.SetArgs([]string{"test"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+
+		cfg := getBoltRouterConfig(testServeCmd)
+		assert.Equal(t, false, cfg.Local)
+		assert.Equal(t, false, cfg.Passthrough)
+		assert.Equal(t, false, cfg.Failover)
+	})
+
+	t.Run("EnvOnly", func(t *testing.T) {
+		os.Setenv("SIDEKICK_BOLTROUTER_LOCAL", "true")
+		os.Setenv("SIDEKICK_BOLTROUTER_PASSTHROUGH", "true")
+		os.Setenv("SIDEKICK_BOLTROUTER_FAILOVER", "true")
+
+		rootCmd.SetArgs([]string{"test"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+
+		cfg := getBoltRouterConfig(testServeCmd)
+		assert.Equal(t, true, cfg.Local)
+		assert.Equal(t, true, cfg.Passthrough)
+		assert.Equal(t, true, cfg.Failover)
+	})
+
+	t.Run("FlagOnly", func(t *testing.T) {
+		rootCmd.SetArgs([]string{"test", "--local", "--passthrough", "--failover"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+
+		cfg := getBoltRouterConfig(testServeCmd)
+		assert.Equal(t, true, cfg.Local)
+		assert.Equal(t, true, cfg.Passthrough)
+		assert.Equal(t, true, cfg.Failover)
+	})
+
+	// Flags should override env vars
+	t.Run("EnvAndFlag", func(t *testing.T) {
+		os.Setenv("SIDEKICK_BOLTROUTER_LOCAL", "true")
+		os.Setenv("SIDEKICK_BOLTROUTER_PASSTHROUGH", "true")
+		os.Setenv("SIDEKICK_BOLTROUTER_FAILOVER", "true")
+
+		rootCmd.SetArgs([]string{"test", "--local=false", "--passthrough=false", "--failover=false"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+
+		cfg := getBoltRouterConfig(testServeCmd)
+		assert.Equal(t, false, cfg.Local)
+		assert.Equal(t, false, cfg.Passthrough)
+		assert.Equal(t, false, cfg.Failover)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,9 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/sys v0.6.0
+	golang.org/x/term v0.1.0
+	gopkg.in/yaml.v2 v2.4.0
 	honnef.co/go/tools v0.4.3
 )
 
@@ -44,9 +47,7 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
 	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/tools v0.4.1-0.20221208213631-3f74d914ae6d // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
- allows the `boltrouter.Config` to be unmarshalled from env or a `config.yaml` file