### PR TITLE
feat(KRY-634): Add sidekick local run to support local bolt endpoint

### DIFF
--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -61,8 +62,11 @@ func (br *BoltRouter) NewBoltRequest(ctx context.Context, logger *zap.Logger, re
 	BoltURL.Path = "/" + BoltURL.Path
 	BoltURL.RawQuery = req.URL.RawQuery
 	req.URL = BoltURL
-	req.URL.Scheme = "https"
-
+	if strings.Contains(BoltURL.Path, "https") {
+		req.URL.Scheme = "https"
+	} else {
+		req.URL.Scheme = "http"
+	}
 	if v := headReq.Header.Get("X-Amz-Security-Token"); v != "" {
 		req.Header.Set("X-Amz-Security-Token", v)
 	}

--- a/boltrouter/config.go
+++ b/boltrouter/config.go
@@ -5,6 +5,9 @@ type Config struct {
 	// For example, boultrouter will not query quicksilver to get endpoints.
 	Local bool `yaml:"Local"`
 
+	// Set the BoltEndpointOverride while running from local mode.
+	BoltEndpointOverride string `yaml:"BoltEndpointOverride"`
+
 	// Enable pass through in Bolt.
 	Passthrough bool `yaml:"Passthrough"`
 
@@ -14,8 +17,9 @@ type Config struct {
 
 func NewConfig() Config {
 	return Config{
-		Local:       false,
-		Passthrough: false,
-		Failover:    true,
+		Local:                false,
+		Passthrough:          false,
+		Failover:             true,
+		BoltEndpointOverride: "",
 	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ func init() {
 func initServerFlags(cmd *cobra.Command) {
 	cmd.Flags().IntP("port", "p", DEFAULT_PORT, "The port for sidekick to listen on.")
 	cmd.Flags().BoolP("local", "l", false, "Run sidekick in local (non cloud) mode. This is mostly use for testing locally.")
+	cmd.Flags().String("bolt-endpoint-override", "", "Specify the local bolt endpoint to override in local mode.")
 	cmd.Flags().Bool("passthrough", false, "Set passthrough flag to bolt requests.")
 	cmd.Flags().BoolP("failover", "f", true, "Enables aws request failover if bolt request fails.")
 }
@@ -70,6 +71,9 @@ func getBoltRouterConfig(cmd *cobra.Command) boltrouter.Config {
 	boltRouterConfig := rootConfig.BoltRouter
 	if cmd.Flags().Lookup("local").Changed {
 		boltRouterConfig.Local, _ = cmd.Flags().GetBool("local")
+	}
+	if cmd.Flags().Lookup("bolt-endpoint-override").Changed {
+		boltRouterConfig.BoltEndpointOverride, _ = cmd.Flags().GetString("bolt-endpoint-override")
 	}
 	if cmd.Flags().Lookup("passthrough").Changed {
 		boltRouterConfig.Passthrough, _ = cmd.Flags().GetBool("passthrough")


### PR DESCRIPTION
This commit introduces support for specifying a local IP address in the SideKick when running in local mode. It allows the BoltRouter to construct the BoltEndpoints using the local IP address and points both main and failover endpoints to the same port (9000).

This would be useful to these locally since bolt and sidekick would be running on samehost.

Unit Test:
- [x] Run Sidekick in local mode
```
$ docker run -p 7075:7075 --env GRANICA_CUSTOM_DOMAIN=localhost --env AWS_REGION="us-east-1" -v ~/.aws/:/root/.aws/ sidekick:latest serve -l --bolt-endpoint-override 192.168.1.183:9000 -f
```

- [x]  Validate S3 access
```
$ aws s3api list-buckets    --endpoint-url http://localhost:7075/
{
    "Buckets": [
        {
            "Name": "n-data-in1",
            "CreationDate": "2023-07-18T14:16:05.360000+00:00"
        },
        {
            "Name": "in1",
            "CreationDate": "2023-07-18T14:16:05.364000+00:00"
        },
        {
            "Name": "n-virtual-recyclebin",
            "CreationDate": "2023-07-17T21:25:02.407000+00:00"
        }
    ],
    "Owner": {
        "DisplayName": "s3server",
        "ID": "fe7272ea58be830e56fe1663b10fafef"
    }
}
```