### PR TITLE
feat(KRY-636): Add support for multiple logging levels and clean up logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ run the following command to learn more about the options:
 go run main.go serve --help
 ```
 
+### Logging
+
+Sidekick supports a `--log-level` argument to control the logging level. By default, the logging level is set to `info`. However, you can set a more verbose log level, such as debug, to enable detailed debugging information. For all available logging options run `./sidekick --help`.
+
 ### Docker
 
 Build the docker image:
@@ -110,7 +114,8 @@ You can find examples on how to setup your aws sdk clients to work with sidekick
 
 You can find more information to integrated sidekick with 3 party tools/frameworks/services [here](./integrations/)
 
-### Pre Built  binaries
+### Pre Built binaries
+
 Sidekick binaries are hosted and released from Github. Please check our [releases page](./releases).
 To download any release of our linux amd64 binary run:
 

--- a/api/api.go
+++ b/api/api.go
@@ -99,13 +99,13 @@ func (a *Api) routeBase(w http.ResponseWriter, req *http.Request) {
 func dumpRequest(logger *zap.Logger, boltReq *boltrouter.BoltRequest) {
 	boltDump, err := httputil.DumpRequest(boltReq.Bolt, true)
 	if err != nil {
-		logger.Error("bolt dump request", zap.Error(err))
+		logger.Error("error dumping bolt request", zap.Error(err))
 		return
 	}
 
 	awsDump, err := httputil.DumpRequest(boltReq.Aws, true)
 	if err != nil {
-		logger.Error("aws dump request", zap.Error(err))
+		logger.Error("error dumping aws request", zap.Error(err))
 		return
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -99,13 +99,13 @@ func (a *Api) routeBase(w http.ResponseWriter, req *http.Request) {
 func dumpRequest(logger *zap.Logger, boltReq *boltrouter.BoltRequest) {
 	boltDump, err := httputil.DumpRequest(boltReq.Bolt, true)
 	if err != nil {
-		logger.Error("error dumping bolt request", zap.Error(err))
+		logger.Error("dumping bolt request", zap.Error(err))
 		return
 	}
 
 	awsDump, err := httputil.DumpRequest(boltReq.Aws, true)
 	if err != nil {
-		logger.Error("error dumping aws request", zap.Error(err))
+		logger.Error("dumping aws request", zap.Error(err))
 		return
 	}
 

--- a/api/session.go
+++ b/api/session.go
@@ -76,7 +76,7 @@ func (a *Api) sessionMiddleware(handler http.Handler) http.HandlerFunc {
 			if session.Logger().Level() == zap.DebugLevel {
 				dump, err := httputil.DumpRequest(r, true)
 				if err != nil {
-					logger.Error("session dump request", zap.Error(err))
+					logger.Error("error dumping session request", zap.Error(err))
 					return
 				}
 				logger.Debug("session request dump", zap.String("dump", string(dump)))

--- a/api/session.go
+++ b/api/session.go
@@ -76,7 +76,7 @@ func (a *Api) sessionMiddleware(handler http.Handler) http.HandlerFunc {
 			if session.Logger().Level() == zap.DebugLevel {
 				dump, err := httputil.DumpRequest(r, true)
 				if err != nil {
-					logger.Error("error dumping session request", zap.Error(err))
+					logger.Error("dumping session request", zap.Error(err))
 					return
 				}
 				logger.Debug("session request dump", zap.String("dump", string(dump)))

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -168,7 +168,7 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		return nil, false, err
 	}
 
-	logger.Info("initial request target", zap.String("target", initialRequestTarget), zap.String("reason", reason))
+	logger.Debug("initial request target", zap.String("target", initialRequestTarget), zap.String("reason", reason))
 
 	if initialRequestTarget == "bolt" {
 		resp, err := br.boltHttpClient.Do(boltReq.Bolt)
@@ -177,7 +177,7 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		} else if !StatusCodeIs2xx(resp.StatusCode) && br.config.Failover {
 			b, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			logger.Warn("bolt request failed", zap.Int("statusCode", resp.StatusCode), zap.String("body", string(b)))
+			logger.Error("bolt request failed", zap.Int("statusCode", resp.StatusCode), zap.String("body", string(b)))
 			resp, err := http.DefaultClient.Do(boltReq.Aws)
 			return resp, true, err
 		}
@@ -188,7 +188,7 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 			return resp, false, err
 		} else if !StatusCodeIs2xx(resp.StatusCode) && resp.StatusCode == 404 {
 			// if the request to AWS failed with 404: NoSuchKey, fall back to Bolt
-			logger.Warn("aws request failed, falling back to bolt", zap.Int("statusCode", resp.StatusCode))
+			logger.Error("aws request failed, falling back to bolt", zap.Int("statusCode", resp.StatusCode))
 			resp, err := br.boltHttpClient.Do(boltReq.Bolt)
 			return resp, true, err
 		}

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/term"
 )
 
-func NewLogger(verbose bool) *zap.Logger {
+func NewLogger(logLevel string) *zap.Logger {
 	var logEncoder zapcore.Encoder
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
 		encoderConfig := getEncoderConfig()
@@ -31,11 +31,27 @@ func NewLogger(verbose bool) *zap.Logger {
 		zap.AddCaller(),
 		zap.AddCallerSkip(1),
 	)
-	zapAtom.SetLevel(zapcore.InfoLevel)
 
-	if verbose {
-		zapAtom.SetLevel(zapcore.DebugLevel)
+	// set zap log level based on logLevel input
+	var zapLogLevel zapcore.Level
+	switch logLevel {
+	case "debug":
+		zapLogLevel = zapcore.DebugLevel
+	case "info":
+		zapLogLevel = zapcore.InfoLevel
+	case "warn":
+		zapLogLevel = zapcore.WarnLevel
+	case "error":
+		zapLogLevel = zapcore.ErrorLevel
+	case "fatal":
+		zapLogLevel = zapcore.FatalLevel
+	case "panic":
+		zapLogLevel = zapcore.PanicLevel
+	default:
+		zapLogLevel = zapcore.InfoLevel
 	}
+
+	zapAtom.SetLevel(zapLogLevel)
 
 	return ret
 }

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/term"
 )
 
-func NewLogger(logLevel string) *zap.Logger {
+func NewLogger(logLevel zapcore.Level) *zap.Logger {
 	var logEncoder zapcore.Encoder
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
 		encoderConfig := getEncoderConfig()
@@ -20,7 +20,7 @@ func NewLogger(logLevel string) *zap.Logger {
 	}
 
 	zapAtom := zap.NewAtomicLevel()
-	zapAtom.SetLevel(zapcore.InfoLevel)
+	zapAtom.SetLevel(logLevel)
 
 	ret := zap.New(
 		zapcore.NewCore(
@@ -32,26 +32,7 @@ func NewLogger(logLevel string) *zap.Logger {
 		zap.AddCallerSkip(1),
 	)
 
-	// set zap log level based on logLevel input
-	var zapLogLevel zapcore.Level
-	switch logLevel {
-	case "debug":
-		zapLogLevel = zapcore.DebugLevel
-	case "info":
-		zapLogLevel = zapcore.InfoLevel
-	case "warn":
-		zapLogLevel = zapcore.WarnLevel
-	case "error":
-		zapLogLevel = zapcore.ErrorLevel
-	case "fatal":
-		zapLogLevel = zapcore.FatalLevel
-	case "panic":
-		zapLogLevel = zapcore.PanicLevel
-	default:
-		zapLogLevel = zapcore.InfoLevel
-	}
-
-	zapAtom.SetLevel(zapLogLevel)
+	zapAtom.SetLevel(logLevel)
 
 	return ret
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ func getVersion() string {
 
 func init() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "make output more verbose")
+	rootCmd.PersistentFlags().StringP("log-level", "", "info", "log level. one of: debug, info, warn, error, fatal, panic")
 	rootCmd.PersistentFlags().StringP("config", "c", "", "read configuration from this file")
 }
 
@@ -41,8 +41,8 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		verbose, _ := cmd.Flags().GetBool("verbose")
-		rootLogger = NewLogger(verbose)
+		logLevel, _ := cmd.Flags().GetString("log-level")
+		rootLogger = NewLogger(logLevel)
 		OnShutdown(func() {
 			_ = rootLogger.Sync()
 		})
@@ -80,7 +80,7 @@ var rootCmd = &cobra.Command{
 		}()
 
 		fmt.Println(asciiArt)
-		rootLogger.Sugar().Infof("Version: %s", getVersion())
+		fmt.Printf("Version: %s\n", getVersion())
 
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"gopkg.in/yaml.v2"
 )
 
@@ -42,7 +43,25 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		logLevel, _ := cmd.Flags().GetString("log-level")
-		rootLogger = NewLogger(logLevel)
+		var zapLogLevel zapcore.Level
+		switch logLevel {
+		case "debug":
+			zapLogLevel = zapcore.DebugLevel
+		case "info":
+			zapLogLevel = zapcore.InfoLevel
+		case "warn":
+			zapLogLevel = zapcore.WarnLevel
+		case "error":
+			zapLogLevel = zapcore.ErrorLevel
+		case "fatal":
+			zapLogLevel = zapcore.FatalLevel
+		case "panic":
+			zapLogLevel = zapcore.PanicLevel
+		default:
+			zapLogLevel = zapcore.InfoLevel
+		}
+		rootLogger = NewLogger(zapLogLevel)
+
 		OnShutdown(func() {
 			_ = rootLogger.Sync()
 		})

--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -59,7 +59,7 @@ func TestAws(t *testing.T) {
 
 func SetupSidekick(t *testing.T, ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
-	logger := cmd.NewLogger(false)
+	logger := cmd.NewLogger("debug")
 
 	go func() {
 		sigs := make(chan os.Signal, 1)

--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -59,7 +59,7 @@ func TestAws(t *testing.T) {
 
 func SetupSidekick(t *testing.T, ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
-	logger := cmd.NewLogger("debug")
+	logger := cmd.NewLogger(zap.DebugLevel)
 
 	go func() {
 		sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
# What it Does
* Deprecate `--verbose` flag in favor of `--log-level` to support granular control of logging level in Sidekick.
* Clean up logging levels and messages in various places.
