### PR TITLE
fix: revert "feat(KRY-634): Add sidekick local run to support local bolt endpoint"

### DIFF
--- a/boltrouter/bolt_info.go
+++ b/boltrouter/bolt_info.go
@@ -33,9 +33,6 @@ func (br *BoltRouter) SelectBoltEndpoint(ctx context.Context, reqMethod string) 
 		if ok && len(availableEndpointsStr) > 0 {
 			randomIndex := rand.Intn(len(availableEndpointsStr))
 			selectedEndpoint := availableEndpointsStr[randomIndex]
-			if br.config.Local {
-				return url.Parse(fmt.Sprintf("http://%s", selectedEndpoint))
-			}
 			return url.Parse(fmt.Sprintf("https://%s", selectedEndpoint))
 		}
 	}
@@ -89,16 +86,7 @@ func (br *BoltRouter) RefreshBoltInfo(ctx context.Context) error {
 func (br *BoltRouter) getBoltInfo(ctx context.Context) (BoltInfo, error) {
 	// If running locally, we can't connect to quicksilver.
 	if br.config.Local {
-		if br.config.BoltEndpointOverride == "" {
-			return BoltInfo{}, nil
-		}
-		endpoints := make(BoltInfo)
-		endpoints["main_write_endpoints"] = []interface{}{br.config.BoltEndpointOverride}
-		endpoints["failover_write_endpoints"] = []interface{}{br.config.BoltEndpointOverride}
-		endpoints["main_read_endpoints"] = []interface{}{br.config.BoltEndpointOverride}
-		endpoints["failover_read_endpoints"] = []interface{}{br.config.BoltEndpointOverride}
-		endpoints["cluster_healthy"] = true
-		return endpoints, nil
+		return BoltInfo{}, nil
 	}
 
 	if br.boltVars.QuicksilverURL.Get() == "" || br.boltVars.Region.Get() == "" {

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -62,11 +61,8 @@ func (br *BoltRouter) NewBoltRequest(ctx context.Context, logger *zap.Logger, re
 	BoltURL.Path = "/" + BoltURL.Path
 	BoltURL.RawQuery = req.URL.RawQuery
 	req.URL = BoltURL
-	if strings.Contains(BoltURL.Path, "https") {
-		req.URL.Scheme = "https"
-	} else {
-		req.URL.Scheme = "http"
-	}
+	req.URL.Scheme = "https"
+
 	if v := headReq.Header.Get("X-Amz-Security-Token"); v != "" {
 		req.Header.Set("X-Amz-Security-Token", v)
 	}

--- a/boltrouter/config.go
+++ b/boltrouter/config.go
@@ -5,9 +5,6 @@ type Config struct {
 	// For example, boultrouter will not query quicksilver to get endpoints.
 	Local bool `yaml:"Local"`
 
-	// Set the BoltEndpointOverride while running from local mode.
-	BoltEndpointOverride string `yaml:"BoltEndpointOverride"`
-
 	// Enable pass through in Bolt.
 	Passthrough bool `yaml:"Passthrough"`
 
@@ -17,9 +14,8 @@ type Config struct {
 
 func NewConfig() Config {
 	return Config{
-		Local:                false,
-		Passthrough:          false,
-		Failover:             true,
-		BoltEndpointOverride: "",
+		Local:       false,
+		Passthrough: false,
+		Failover:    true,
 	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,7 +23,6 @@ func init() {
 func initServerFlags(cmd *cobra.Command) {
 	cmd.Flags().IntP("port", "p", DEFAULT_PORT, "The port for sidekick to listen on.")
 	cmd.Flags().BoolP("local", "l", false, "Run sidekick in local (non cloud) mode. This is mostly use for testing locally.")
-	cmd.Flags().String("bolt-endpoint-override", "", "Specify the local bolt endpoint to override in local mode.")
 	cmd.Flags().Bool("passthrough", false, "Set passthrough flag to bolt requests.")
 	cmd.Flags().BoolP("failover", "f", true, "Enables aws request failover if bolt request fails.")
 }
@@ -71,9 +70,6 @@ func getBoltRouterConfig(cmd *cobra.Command) boltrouter.Config {
 	boltRouterConfig := rootConfig.BoltRouter
 	if cmd.Flags().Lookup("local").Changed {
 		boltRouterConfig.Local, _ = cmd.Flags().GetBool("local")
-	}
-	if cmd.Flags().Lookup("bolt-endpoint-override").Changed {
-		boltRouterConfig.BoltEndpointOverride, _ = cmd.Flags().GetString("bolt-endpoint-override")
 	}
 	if cmd.Flags().Lookup("passthrough").Changed {
 		boltRouterConfig.Passthrough, _ = cmd.Flags().GetBool("passthrough")


### PR DESCRIPTION
Reverts project-n-oss/sidekick#49

Breaking change in non-local mode. All requests to remote replicas being made over HTTP.

```
2023-07-26:00:10:46.166	ERROR	api/api.go:72	internal error	{"request_id": "uZ4n1PbZbhpr-mnOBvIuhjS3Urs", "user_agent": "aws-cli/2.9.19 Python/3.9.16 Linux/6.1.34-59.116.amzn2023.x86_64 source/x86_64.amzn.2023 prompt/off command/s3api.list-objects", "error": "Get \"http://10.196.143.185/km-us-west-2?encoding-type=url\": dial tcp 10.196.143.185:80: connect: connection refused"}
```