### PR TITLE
fix: Fix the regression caused by local sidekick logic

### DIFF
--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -80,8 +80,11 @@ func (br *BoltRouter) NewBoltRequest(ctx context.Context, logger *zap.Logger, re
 	BoltURL.Path = "/" + BoltURL.Path
 	BoltURL.RawQuery = req.URL.RawQuery
 	req.URL = BoltURL
-	req.URL.Scheme = "https"
-
+	if br.config.Local {
+		req.URL.Scheme = "http"
+	} else {
+		req.URL.Scheme = "https"
+	}
 	if v := headReq.Header.Get("X-Amz-Security-Token"); v != "" {
 		req.Header.Set("X-Amz-Security-Token", v)
 	}

--- a/boltrouter/config.go
+++ b/boltrouter/config.go
@@ -5,6 +5,9 @@ type Config struct {
 	// For example, it will not query quicksilver to get endpoints.
 	Local bool `yaml:"Local"`
 
+	// Set the BoltEndpointOverride while running from local mode.
+	BoltEndpointOverride string `yaml:"BoltEndpointOverride"`
+
 	// Enable pass through in Bolt.
 	Passthrough bool `yaml:"Passthrough"`
 
@@ -13,7 +16,8 @@ type Config struct {
 }
 
 var DefaultConfig = Config{
-	Local:       false,
-	Passthrough: false,
-	Failover:    true,
+	Local:                false,
+	Passthrough:          false,
+	Failover:             true,
+	BoltEndpointOverride: "",
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -24,6 +24,7 @@ func init() {
 func initServerFlags(cmd *cobra.Command) {
 	cmd.Flags().IntP("port", "p", DEFAULT_PORT, "The port for sidekick to listen on.")
 	cmd.Flags().BoolP("local", "l", false, "Run sidekick in local (non cloud) mode. This is mostly use for testing locally.")
+	cmd.Flags().String("bolt-endpoint-override", "", "Specify the local bolt endpoint with port to override in local mode. e.g: <local-bolt-ip>:9000")
 	cmd.Flags().Bool("passthrough", false, "Set passthrough flag to bolt requests.")
 	cmd.Flags().BoolP("failover", "f", true, "Enables aws request failover if bolt request fails.")
 }
@@ -75,6 +76,9 @@ func getBoltRouterConfig(cmd *cobra.Command) boltrouter.Config {
 	boltRouterConfig := rootConfig.BoltRouter
 	if cmd.Flags().Lookup("local").Changed {
 		boltRouterConfig.Local, _ = cmd.Flags().GetBool("local")
+	}
+	if cmd.Flags().Lookup("bolt-endpoint-override").Changed {
+		boltRouterConfig.BoltEndpointOverride, _ = cmd.Flags().GetString("bolt-endpoint-override")
 	}
 	if cmd.Flags().Lookup("passthrough").Changed {
 		boltRouterConfig.Passthrough, _ = cmd.Flags().GetBool("passthrough")


### PR DESCRIPTION
# What it Does
BoltURL.Path may or may not have "https". Hence, we should already default to https for non-local runs.

# Unit Test # 
-[x] Verified with local setup
```
$ docker run -p 7075:7075 --env GRANICA_CUSTOM_DOMAIN=localhost --env AWS_REGION="us-east-1" -v ~/.aws/:/root/.aws/ sidekick:latest serve -l  -f --bolt-endpoint-override 192.168.1.118:9000
```