### PR TITLE
feat: return proper error if boltInfo is empty

### DIFF
--- a/boltrouter/bolt_info.go
+++ b/boltrouter/bolt_info.go
@@ -20,6 +20,11 @@ const (
 func (br *BoltRouter) SelectBoltEndpoint(ctx context.Context, reqMethod string) (*url.URL, error) {
 	preferredOrder := br.getPreferredEndpointOrder(reqMethod)
 	boltEndpoints := br.boltVars.BoltInfo.Get()
+
+	if len(boltEndpoints) == 0 {
+		return nil, fmt.Errorf("boltInfo is empty")
+	}
+
 	for _, key := range preferredOrder {
 		availableEndpoints, ok := boltEndpoints[key]
 		availableEndpointsSlice, castOk := availableEndpoints.([]interface{})


### PR DESCRIPTION
# What it Does

Check if `boltInfo` is empty (this can happen when Quicksilver is down or returning nothing) and return an appropriate error. 

Previously this was bubbling up as

```
level":"ERROR","ts":"2023-07-25:23:28:22.188","caller":"api/api.go:62","msg":"internal error","request_id":"hPbxEnzHaa_1oUrWq9VqMbfmCL0","user_agent":"Boto3/1.28.5 md/Botocore#1.31.5 ua/2.0 os/linux#4.14.318-241.531.amzn2.x86_64 md/arch#x86_64 lang/python#3.7.16 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.5","error":"could not cast availableEndpoints to []string"}
```

and now the error log printed is

```
{"level":"ERROR","ts":"2023-07-26:01:08:21.203","caller":"api/api.go:62","msg":"internal error","request_id":"KLPqhpH1UAno6dcGkULV-ArSpPM","user_agent":"aws-cli/2.9.19 Python/3.9.16 Linux/6.1.34-59.116.amzn2023.x86_64 source/x86_64.amzn.2023 prompt/off command/s3api.get-object","error":"boltInfo is empty"}
```
