### PR TITLE
feat: always log bolt request analytics in debug mode

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -121,11 +121,12 @@ func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytic
 	defaultValue := "N/A"
 
 	logger.Debug("BoltRequestAnalytics dump",
+		zap.Any("ObjectKey", orDefault(analytics.ObjectKey, defaultValue)),
 		zap.Any("RequestBodySize", orDefault(analytics.RequestBodySize, defaultValue)),
 		zap.Any("Method", orDefault(analytics.Method, defaultValue)),
 		zap.Any("InitialRequestTarget", orDefault(analytics.InitialRequestTarget, defaultValue)),
 		zap.Any("InitialRequestTargetReason", orDefault(analytics.InitialRequestTargetReason, defaultValue)),
-		zap.Any("BoltRequestUrl", orDefault(analytics.BoltRequestUrl, defaultValue)),
+		zap.Any("BoltReplicaIp", orDefault(analytics.BoltRequestUrl, defaultValue)),
 		zap.Any("BoltRequestDuration", analytics.BoltRequestDuration),
 		zap.Any("BoltRequestResponseStatusCode", analytics.BoltRequestResponseStatusCode),
 		zap.Any("AwsRequestDuration", analytics.AwsRequestDuration),

--- a/api/api.go
+++ b/api/api.go
@@ -125,6 +125,7 @@ func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytic
 		zap.Any("Method", orDefault(analytics.Method, defaultValue)),
 		zap.Any("InitialRequestTarget", orDefault(analytics.InitialRequestTarget, defaultValue)),
 		zap.Any("InitialRequestTargetReason", orDefault(analytics.InitialRequestTargetReason, defaultValue)),
+		zap.Any("BoltRequestUrl", orDefault(analytics.BoltRequestUrl, defaultValue)),
 		zap.Any("BoltRequestDuration", analytics.BoltRequestDuration),
 		zap.Any("BoltRequestResponseStatusCode", analytics.BoltRequestResponseStatusCode),
 		zap.Any("AwsRequestDuration", analytics.AwsRequestDuration),

--- a/api/api.go
+++ b/api/api.go
@@ -70,7 +70,7 @@ func (a *Api) routeBase(w http.ResponseWriter, req *http.Request) {
 	resp, failover, analytics, err := sess.br.DoBoltRequest(sess.Logger(), boltReq)
 
 	if sess.Logger().Level() == zap.DebugLevel {
-		dumpAnalytics(sess.Logger(), analytics)
+		dumpAnalytics(sess.Logger(), analytics, err)
 	}
 
 	if err != nil {
@@ -117,8 +117,10 @@ func dumpRequest(logger *zap.Logger, boltReq *boltrouter.BoltRequest) {
 	logger.Debug("BoltRequest dump", zap.String("bolt", string(boltDump)), zap.String("aws", string(awsDump)))
 }
 
-func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytics) {
+func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytics, err error) {
 	defaultValue := "N/A"
+	isError := err != nil
+
 	logger.Debug("BoltRequestAnalytics dump",
 		zap.Any("RequestBodySize", orDefault(analytics.RequestBodySize, defaultValue)),
 		zap.Any("Method", orDefault(analytics.Method, defaultValue)),
@@ -128,6 +130,7 @@ func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytic
 		zap.Any("BoltRequestResponseStatusCode", analytics.BoltRequestResponseStatusCode),
 		zap.Any("AwsRequestDuration", analytics.AwsRequestDuration),
 		zap.Any("AwsRequestResponseStatusCode", analytics.AwsRequestResponseStatusCode),
+		zap.Any("IsError", isError),
 	)
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -135,7 +135,7 @@ func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytic
 }
 
 func orDefault(value interface{}, defaultValue interface{}) interface{} {
-	if value == nil {
+	if value == nil || value == "" || value == 0 {
 		return defaultValue
 	}
 	return value

--- a/api/api.go
+++ b/api/api.go
@@ -127,10 +127,10 @@ func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytic
 		zap.Any("InitialRequestTarget", orDefault(analytics.InitialRequestTarget, defaultValue)),
 		zap.Any("InitialRequestTargetReason", orDefault(analytics.InitialRequestTargetReason, defaultValue)),
 		zap.Any("BoltReplicaIp", orDefault(analytics.BoltRequestUrl, defaultValue)),
-		zap.Any("BoltRequestDuration", analytics.BoltRequestDuration),
-		zap.Any("BoltRequestResponseStatusCode", analytics.BoltRequestResponseStatusCode),
-		zap.Any("AwsRequestDuration", analytics.AwsRequestDuration),
-		zap.Any("AwsRequestResponseStatusCode", analytics.AwsRequestResponseStatusCode),
+		zap.Any("BoltRequestDuration", orDefault(analytics.BoltRequestDuration, defaultValue)),
+		zap.Any("BoltRequestResponseStatusCode", orDefault(analytics.BoltRequestResponseStatusCode, defaultValue)),
+		zap.Any("AwsRequestDuration", orDefault(analytics.AwsRequestDuration, defaultValue)),
+		zap.Any("AwsRequestResponseStatusCode", orDefault(analytics.AwsRequestResponseStatusCode, defaultValue)),
 		zap.Any("Error", orDefault(err, defaultValue)),
 	)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -119,7 +119,6 @@ func dumpRequest(logger *zap.Logger, boltReq *boltrouter.BoltRequest) {
 
 func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytics, err error) {
 	defaultValue := "N/A"
-	isError := err != nil
 
 	logger.Debug("BoltRequestAnalytics dump",
 		zap.Any("RequestBodySize", orDefault(analytics.RequestBodySize, defaultValue)),
@@ -130,7 +129,7 @@ func dumpAnalytics(logger *zap.Logger, analytics *boltrouter.BoltRequestAnalytic
 		zap.Any("BoltRequestResponseStatusCode", analytics.BoltRequestResponseStatusCode),
 		zap.Any("AwsRequestDuration", analytics.AwsRequestDuration),
 		zap.Any("AwsRequestResponseStatusCode", analytics.AwsRequestResponseStatusCode),
-		zap.Any("IsError", isError),
+		zap.Any("Error", orDefault(err, defaultValue)),
 	)
 }
 

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -18,6 +18,7 @@ type BoltRequest struct {
 }
 
 type BoltRequestAnalytics struct {
+	ObjectKey                     string
 	RequestBodySize               int
 	Method                        string
 	InitialRequestTarget          string
@@ -175,11 +176,12 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 	initialRequestTarget, reason, err := br.SelectInitialRequestTarget()
 
 	boltRequestAnalytics := &BoltRequestAnalytics{
+		ObjectKey:                     boltReq.Bolt.URL.Path,
 		RequestBodySize:               int(boltReq.Bolt.ContentLength),
 		Method:                        boltReq.Bolt.Method,
 		InitialRequestTarget:          initialRequestTarget,
 		InitialRequestTargetReason:    reason,
-		BoltRequestUrl:                boltReq.Bolt.URL.String(),
+		BoltRequestUrl:                boltReq.Bolt.URL.Hostname(),
 		BoltRequestDuration:           time.Duration(0),
 		BoltRequestResponseStatusCode: -1,
 		AwsRequestDuration:            -1,

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -22,6 +22,7 @@ type BoltRequestAnalytics struct {
 	Method                        string
 	InitialRequestTarget          string
 	InitialRequestTargetReason    string
+	BoltRequestUrl                string
 	BoltRequestDuration           time.Duration
 	BoltRequestResponseStatusCode int
 	AwsRequestDuration            time.Duration
@@ -178,6 +179,7 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		Method:                        boltReq.Bolt.Method,
 		InitialRequestTarget:          initialRequestTarget,
 		InitialRequestTargetReason:    reason,
+		BoltRequestUrl:                boltReq.Bolt.URL.String(),
 		BoltRequestDuration:           time.Duration(0),
 		BoltRequestResponseStatusCode: -1,
 		AwsRequestDuration:            -1,

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -172,6 +172,7 @@ func newFailoverAwsRequest(ctx context.Context, req *http.Request, awsCred aws.C
 // DoBoltRequest will return a BoltRequestAnalytics struct with analytics about the request.
 func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*http.Response, bool, *BoltRequestAnalytics, error) {
 	boltRequestAnalytics := &BoltRequestAnalytics{}
+	boltRequestAnalytics.Method = boltReq.Bolt.Method
 	boltRequestAnalytics.RequestBodySize = int(boltReq.Bolt.ContentLength)
 
 	initialRequestTarget, reason, err := br.SelectInitialRequestTarget()

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -171,13 +171,19 @@ func newFailoverAwsRequest(ctx context.Context, req *http.Request, awsCred aws.C
 // DoboltRequest will return a bool indicating if the request was a failover.
 // DoBoltRequest will return a BoltRequestAnalytics struct with analytics about the request.
 func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*http.Response, bool, *BoltRequestAnalytics, error) {
-	boltRequestAnalytics := &BoltRequestAnalytics{}
-	boltRequestAnalytics.Method = boltReq.Bolt.Method
-	boltRequestAnalytics.RequestBodySize = int(boltReq.Bolt.ContentLength)
-
 	initialRequestTarget, reason, err := br.SelectInitialRequestTarget()
-	boltRequestAnalytics.InitialRequestTarget = initialRequestTarget
-	boltRequestAnalytics.InitialRequestTargetReason = reason
+
+	boltRequestAnalytics := &BoltRequestAnalytics{
+		RequestBodySize:               int(boltReq.Bolt.ContentLength),
+		Method:                        boltReq.Bolt.Method,
+		InitialRequestTarget:          initialRequestTarget,
+		InitialRequestTargetReason:    reason,
+		BoltRequestDuration:           time.Duration(0),
+		BoltRequestResponseStatusCode: -1,
+		AwsRequestDuration:            -1,
+		AwsRequestResponseStatusCode:  -1,
+	}
+
 	if err != nil {
 		return nil, false, boltRequestAnalytics, err
 	}

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -200,7 +200,13 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		duration := time.Since(beginTime)
 		boltRequestAnalytics.BoltRequestDuration = duration
 		if err != nil {
-			boltRequestAnalytics.BoltRequestResponseStatusCode = resp.StatusCode
+			// if resp is not nil, we can get the status code
+			// if resp is nil, we can't get the status code so we set it to 0
+			if resp != nil {
+				boltRequestAnalytics.BoltRequestResponseStatusCode = resp.StatusCode
+			} else {
+				boltRequestAnalytics.BoltRequestResponseStatusCode = 0
+			}
 			return resp, false, boltRequestAnalytics, err
 		} else if !StatusCodeIs2xx(resp.StatusCode) && br.config.Failover {
 			b, _ := io.ReadAll(resp.Body)
@@ -211,7 +217,13 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 			duration := time.Since(beginTime)
 			boltRequestAnalytics.AwsRequestDuration = duration
 			if err != nil {
-				boltRequestAnalytics.AwsRequestResponseStatusCode = resp.StatusCode
+				// if resp is not nil, we can get the status code
+				// if resp is nil, we can't get the status code so we set it to 0
+				if resp != nil {
+					boltRequestAnalytics.AwsRequestResponseStatusCode = resp.StatusCode
+				} else {
+					boltRequestAnalytics.AwsRequestResponseStatusCode = 0
+				}
 			}
 			return resp, true, boltRequestAnalytics, err
 		}
@@ -223,7 +235,13 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		duration := time.Since(beginTime)
 		boltRequestAnalytics.AwsRequestDuration = duration
 		if err != nil {
-			boltRequestAnalytics.AwsRequestResponseStatusCode = resp.StatusCode
+			// if resp is not nil, we can get the status code
+			// if resp is nil, we can't get the status code so we set it to 0
+			if resp != nil {
+				boltRequestAnalytics.AwsRequestResponseStatusCode = resp.StatusCode
+			} else {
+				boltRequestAnalytics.AwsRequestResponseStatusCode = 0
+			}
 			return resp, false, boltRequestAnalytics, err
 		} else if !StatusCodeIs2xx(resp.StatusCode) && resp.StatusCode == 404 {
 			// if the request to AWS failed with 404: NoSuchKey, fall back to Bolt
@@ -233,7 +251,13 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 			duration := time.Since(beginTime)
 			boltRequestAnalytics.BoltRequestDuration = duration
 			if err != nil {
-				boltRequestAnalytics.BoltRequestResponseStatusCode = resp.StatusCode
+				// if resp is not nil, we can get the status code
+				// if resp is nil, we can't get the status code so we set it to 0
+				if resp != nil {
+					boltRequestAnalytics.BoltRequestResponseStatusCode = resp.StatusCode
+				} else {
+					boltRequestAnalytics.BoltRequestResponseStatusCode = 0
+				}
 			}
 			return resp, true, boltRequestAnalytics, err
 		}

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -200,12 +200,8 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		duration := time.Since(beginTime)
 		boltRequestAnalytics.BoltRequestDuration = duration
 		if err != nil {
-			// if resp is not nil, we can get the status code
-			// if resp is nil, we can't get the status code so we set it to 0
 			if resp != nil {
 				boltRequestAnalytics.BoltRequestResponseStatusCode = resp.StatusCode
-			} else {
-				boltRequestAnalytics.BoltRequestResponseStatusCode = 0
 			}
 			return resp, false, boltRequestAnalytics, err
 		} else if !StatusCodeIs2xx(resp.StatusCode) && br.config.Failover {
@@ -217,12 +213,8 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 			duration := time.Since(beginTime)
 			boltRequestAnalytics.AwsRequestDuration = duration
 			if err != nil {
-				// if resp is not nil, we can get the status code
-				// if resp is nil, we can't get the status code so we set it to 0
 				if resp != nil {
 					boltRequestAnalytics.AwsRequestResponseStatusCode = resp.StatusCode
-				} else {
-					boltRequestAnalytics.AwsRequestResponseStatusCode = 0
 				}
 			}
 			return resp, true, boltRequestAnalytics, err
@@ -235,12 +227,8 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		duration := time.Since(beginTime)
 		boltRequestAnalytics.AwsRequestDuration = duration
 		if err != nil {
-			// if resp is not nil, we can get the status code
-			// if resp is nil, we can't get the status code so we set it to 0
 			if resp != nil {
 				boltRequestAnalytics.AwsRequestResponseStatusCode = resp.StatusCode
-			} else {
-				boltRequestAnalytics.AwsRequestResponseStatusCode = 0
 			}
 			return resp, false, boltRequestAnalytics, err
 		} else if !StatusCodeIs2xx(resp.StatusCode) && resp.StatusCode == 404 {
@@ -251,12 +239,8 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 			duration := time.Since(beginTime)
 			boltRequestAnalytics.BoltRequestDuration = duration
 			if err != nil {
-				// if resp is not nil, we can get the status code
-				// if resp is nil, we can't get the status code so we set it to 0
 				if resp != nil {
 					boltRequestAnalytics.BoltRequestResponseStatusCode = resp.StatusCode
-				} else {
-					boltRequestAnalytics.BoltRequestResponseStatusCode = 0
 				}
 			}
 			return resp, true, boltRequestAnalytics, err

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -190,6 +190,7 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 		duration := time.Since(beginTime)
 		boltRequestAnalytics.BoltRequestDuration = duration
 		if err != nil {
+			boltRequestAnalytics.BoltRequestResponseStatusCode = resp.StatusCode
 			return resp, false, boltRequestAnalytics, err
 		} else if !StatusCodeIs2xx(resp.StatusCode) && br.config.Failover {
 			b, _ := io.ReadAll(resp.Body)
@@ -226,6 +227,7 @@ func (br *BoltRouter) DoBoltRequest(logger *zap.Logger, boltReq *BoltRequest) (*
 			}
 			return resp, true, boltRequestAnalytics, err
 		}
+		boltRequestAnalytics.AwsRequestResponseStatusCode = resp.StatusCode
 		return resp, false, boltRequestAnalytics, nil
 	}
 }


### PR DESCRIPTION
# What it Does

* Move analytics log dump outside of `DoBoltRequest` such as it is always dumped in debug log mode even when the `http.Do` itself errors.
* Only set bolt response status codes when resp is not nil to avoid invalid memory accesses.

example dump
```json
{"level":"DEBUG","ts":"2023-08-11:11:19:44.360","caller":"api/api.go:73","msg":"BoltRequestAnalytics dump","request_id":"RI5ePJirWDOY_TxG6hzVsmgXMiU","user_agent":"Boto3/1.28.11 md/Botocore#1.31.11 ua/2.0 os/linux#4.14.320-242.534.amzn2.x86_64 md/arch#x86_64 lang/python#3.7.16 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.11","ObjectKey":"/gagan-empty-bucket-3/nylas-sidekick-km-0/c33221773e3d2c8b41fb48c3d8cc66a1-47634099258955648855-4052","RequestBodySize":6144,"Method":"PUT","InitialRequestTarget":"bolt","InitialRequestTargetReason":"traffic splitting","BoltReplicaIp":"10.199.142.226","BoltRequestDuration":0.151265919,"BoltRequestResponseStatusCode":200,"AwsRequestDuration":-0.000000001,"AwsRequestResponseStatusCode":-1,"Error":"N/A"}
```