### PR TITLE
feat: Enhance Initial Request Target Selection

### DIFF
--- a/boltrouter/bolt_request_test.go
+++ b/boltrouter/bolt_request_test.go
@@ -76,13 +76,14 @@ func TestBoltRequestFailover(t *testing.T) {
 	allReadEndpoints := append(mainReadEndpoints, failoverReadEndpoints...)
 	// register error responders for all read endpoints
 	for _, endpoint := range allReadEndpoints {
-		httpmock.RegisterResponder("GET", fmt.Sprintf("https://%s/test.projectn.co", endpoint),
+		httpmock.RegisterResponder("GET", fmt.Sprintf("https://%s/test.granica.ai123456", endpoint),
 			func(req *http.Request) (*http.Response, error) {
 				return httpmock.NewStringResponse(500, "SERVER ERROR"), fmt.Errorf("s3 error")
 			})
 	}
 
-	httpmock.RegisterResponder("GET", "https://bolt.s3.us-west-2.amazonaws.com/test.projectn.co",
+	httpmock.RegisterResponder("GET", "https://bolt.s3.us-west-2.amazonaws.com/test.granica.ai123456",
+
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewStringResponse(200, "OK"), nil
 		})
@@ -97,15 +98,15 @@ func TestBoltRequestFailover(t *testing.T) {
 	overrideCrunchTrafficPct(br, "100")
 
 	body := strings.NewReader(randomdata.Paragraph())
-	req, err := http.NewRequest(http.MethodGet, "test.projectn.co", body)
+	req, err := http.NewRequest(http.MethodGet, "test.granica.ai123456", body)
 	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIA3Y7DLM2EYWSYCN5P/20230511/us-west-2/s3/aws4_request, SignedHeaders=accept-encoding;amz-sdk-invocation-id;amz-sdk-request;host;x-amz-content-sha256;x-amz-date, Signature=6447287d46d333a010e224191d64c31b9738cc37886aadb7753a0a579a30edc6")
 	require.NoError(t, err)
 
 	boltReq, err := br.NewBoltRequest(ctx, logger, req)
 	require.NoError(t, err)
 	require.NotNil(t, boltReq)
-
 	_, failover, _, err := br.DoRequest(logger, boltReq)
+
 	require.Error(t, err, failover)
 	require.False(t, failover, err)
 
@@ -129,13 +130,14 @@ func TestBoltRequestPanic(t *testing.T) {
 	allReadEndpoints := append(mainReadEndpoints, failoverReadEndpoints...)
 	// register panic responders for all read endpoints
 	for _, endpoint := range allReadEndpoints {
-		httpmock.RegisterResponder("GET", fmt.Sprintf("https://%s/test.projectn.co", endpoint),
+		httpmock.RegisterResponder("GET", fmt.Sprintf("https://%s/test.granica.ai123456", endpoint),
 			func(req *http.Request) (*http.Response, error) {
 				panic("Simulated panic during request")
 			})
 	}
+	
+	httpmock.RegisterResponder("GET", "https://bolt.s3.us-west-2.amazonaws.com/test.granica.ai123456",
 
-	httpmock.RegisterResponder("GET", "https://bolt.s3.us-west-2.amazonaws.com/test.projectn.co",
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewStringResponse(200, "OK"), nil
 		})
@@ -151,10 +153,9 @@ func TestBoltRequestPanic(t *testing.T) {
 	overrideCrunchTrafficPct(br, "100")
 
 	body := strings.NewReader(randomdata.Paragraph())
-	req, err := http.NewRequest(http.MethodGet, "test.projectn.co", body)
+	req, err := http.NewRequest(http.MethodGet, "test.granica.ai123456", body)
 	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIA3Y7DLM2EYWSYCN5P/20230511/us-west-2/s3/aws4_request, SignedHeaders=accept-encoding;amz-sdk-invocation-id;amz-sdk-request;host;x-amz-content-sha256;x-amz-date, Signature=6447287d46d333a010e224191d64c31b9738cc37886aadb7753a0a579a30edc6")
 	require.NoError(t, err)
-
 	boltReq, err := br.NewBoltRequest(ctx, logger, req)
 	require.NoError(t, err)
 	require.NotNil(t, boltReq)

--- a/boltrouter/bolt_router.go
+++ b/boltrouter/bolt_router.go
@@ -17,8 +17,7 @@ type BoltRouter struct {
 	boltHttpClient     *http.Client
 	standardHttpClient *http.Client
 	boltVars           *BoltVars
-
-	logger *zap.Logger
+	logger             *zap.Logger
 }
 
 // NewBoltRouter creates a new BoltRouter.

--- a/boltrouter/config.go
+++ b/boltrouter/config.go
@@ -1,5 +1,12 @@
 package boltrouter
 
+type CrunchTrafficSplitType string
+
+const (
+	CrunchTrafficSplitByObjectKeyHash CrunchTrafficSplitType = "objectkeyhash"
+	CrunchTrafficSplitByRandomRequest CrunchTrafficSplitType = "random"
+)
+
 type Config struct {
 	// If set, boltrouter will run in local mode.
 	// For example, it will not query quicksilver to get endpoints.
@@ -13,6 +20,12 @@ type Config struct {
 
 	// Enable failover to a AWS request if the Bolt request fails or vice-versa.
 	Failover bool `yaml:"Failover"`
+
+	// There are two ways to split the traffic between bolt and object store
+	// 1. Random Crunch Traffic Split
+	// 2. Hash Based Crunch Traffic Split
+	// Random approach could cause data inconsistency if the requests are mix of GET and PUT.
+	CrunchTrafficSplit CrunchTrafficSplitType `yaml:"CrunchTrafficSplit"`
 }
 
 var DefaultConfig = Config{
@@ -20,4 +33,5 @@ var DefaultConfig = Config{
 	Passthrough:          false,
 	Failover:             true,
 	BoltEndpointOverride: "",
+	CrunchTrafficSplit:   CrunchTrafficSplitByObjectKeyHash,
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -27,6 +27,7 @@ func initServerFlags(cmd *cobra.Command) {
 	cmd.Flags().String("bolt-endpoint-override", "", "Specify the local bolt endpoint with port to override in local mode. e.g: <local-bolt-ip>:9000")
 	cmd.Flags().Bool("passthrough", false, "Set passthrough flag to bolt requests.")
 	cmd.Flags().BoolP("failover", "f", true, "Enables aws request failover if bolt request fails.")
+	cmd.Flags().String("crunch-traffic-split", "objectkeyhash", "Specify the crunch traffic split strategy: random or objectkeyhash")
 }
 
 var serveCmd = &cobra.Command{
@@ -85,6 +86,10 @@ func getBoltRouterConfig(cmd *cobra.Command) boltrouter.Config {
 	}
 	if cmd.Flags().Lookup("failover").Changed {
 		boltRouterConfig.Failover, _ = cmd.Flags().GetBool("failover")
+	}
+	if cmd.Flags().Lookup("crunch-traffic-split").Changed {
+		crunchTrafficSplitStr, _ := cmd.Flags().GetString("crunch-traffic-split")
+		boltRouterConfig.CrunchTrafficSplit = boltrouter.CrunchTrafficSplitType(crunchTrafficSplitStr)
 	}
 	return boltRouterConfig
 }


### PR DESCRIPTION
# What it Does
This update refines the logic for selecting the initial request target within the BoltRouter module, while expanding its capabilities. By incorporating support for both random and object hash-based traffic distribution, we optimize routing decisions to align with specific use cases.

Previously, the selection process relied solely on the Random Crunch Traffic Split strategy, which could lead to data inconsistencies when handling mixed GET and PUT requests.

With this enhancement, the `SelectInitialRequestTarget` function now considers the `CrunchTrafficSplit` configuration parameter. This parameter accepts two values: "CrunchTrafficSplitByRandomRequest" and "CrunchTrafficSplitByObjectKeyHash". When set to "CrunchTrafficSplitByRandomRequest", the routing process continues 
as before, distributing traffic randomly. On the other hand, when set to "CrunchTrafficSplitByObjectKeyHash", the routing decision is made based on the crc32 hash value of the request's object key. By using CRC32 checksum for hash calculation, we achieve faster processing and lower memory consumption compared to MD5 or SHA-256.

## Unit Test ##
- [x] Verified unit tests passing locally
- [x] Verify code coverage: before 68.4%, after 69%
  