### PR TITLE
feat: Change logging level from Info to Debug for reduced console noise

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -101,7 +101,7 @@ func (a *Api) routeBase(w http.ResponseWriter, req *http.Request) {
 		body := boltrouter.CopyRespBody(resp)
 		b, _ := io.ReadAll(body)
 		body.Close()
-		sess.Logger().Warn("Status code is not 2xx in s3 response", zap.String("body", string(b)))
+		sess.Logger().Debug("Status code is not 2xx in s3 response", zap.String("body", string(b)))
 	}
 
 	w.WriteHeader(resp.StatusCode)

--- a/api/session.go
+++ b/api/session.go
@@ -73,7 +73,7 @@ func (a *Api) sessionMiddleware(handler http.Handler) http.HandlerFunc {
 				zap.String("host", host),
 				zap.String("path", path),
 			)
-			logger.Info(method + " " + path)
+			logger.Debug(method + " " + path)
 			if session.Logger().Level() == zap.DebugLevel {
 				dump, err := httputil.DumpRequest(r, true)
 				if err != nil {


### PR DESCRIPTION
# What it Does
Adjusted logging levels from Info to Debug to declutter the console of extraneous messages during bolt request failures.
After this change, we reduce the number of console messages from 4 to 1.

# Unit Test
## Before
```
{"level":"ERROR","ts":"2023-09-11:22:13:56.589","caller":"boltrouter/bolt_request.go:221","msg":"bolt request failed","request_id":"AJW-3dBHISAjyR8yWtojqffa18Q","user_agent":"aws-cli/2.13.1 Python/3.11.4 Darwin/22.5.0 source/x86_64 prompt/off command/s3.cp","code":404,"body":""}
{"level":"WARN","ts":"2023-09-11:22:13:56.749","caller":"http/server.go:2122","msg":"Status code is not 2xx in s3 response","request_id":"AJW-3dBHISAjyR8yWtojqffa18Q","user_agent":"aws-cli/2.13.1 Python/3.11.4 Darwin/22.5.0 source/x86_64 prompt/off command/s3.cp","statusCode":400,"failover":true,"endpt":"aws","body":""}
{"level":"INFO","ts":"2023-09-11:22:13:56.749","caller":"api/session.go:91","msg":"HEAD /ashwin-test-1/1mb","request_id":"AJW-3dBHISAjyR8yWtojqffa18Q","user_agent":"aws-cli/2.13.1 Python/3.11.4 Darwin/22.5.0 source/x86_64 prompt/off command/s3.cp","statusCode":400,"failover":true,"endpt":"aws","duration":0.166866171,"method":"HEAD","host":"127.0.0.1:7075","path":"/ashwin-test-1/1mb"}
{"level":"INFO","ts":"2023-09-11:22:13:56.766","caller":"api/session.go:91","msg":"HEAD /ashwin-test-1","request_id":"b82XBGtv_tU9dGas_0LXUUqymdU","user_agent":"aws-cli/2.13.1 Python/3.11.4 Darwin/22.5.0 source/x86_64 prompt/off command/s3.cp","statusCode":200,"failover":false,"endpt":"192.168.1.118","duration":0.007548408,"method":"HEAD","host":"127.0.0.1:7075","path":"/ashwin-test-1"}
cd ..^C{"level":"INFO","ts":"2023-09-11:22:17:37.804","caller":"cmd/root.go:83","msg":"received signal, shutting down","signal":"interrupt"}
```

##After

```
{"level":"ERROR","ts":"2023-09-11:22:22:03.146","caller":"boltrouter/bolt_request.go:221","msg":"bolt request failed","request_id":"1A4vERDh4y42zVrwGN4ejyWoIl4","user_agent":"aws-cli/2.13.1 Python/3.11.4 Darwin/22.5.0 source/x86_64 prompt/off command/s3.cp","code":404,"body":""}
```
