### PR TITLE
feat: add 404 failover behavior control via cli arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ Traffic splitting configuration is managed through the `client-behavior-params` 
 
 ### Fallback on 404
 
-If sidekick can't find your object in Bolt, sidekick tries to find the object in S3. This happens transparently to the client, and it doesn't need any client retries.
+If Sidekick can't find your object in Crunch, Sidekick tries to find the object in S3/GCS. This happens transparently to the client, and it doesn't need any client retries.
+
+If you'd like to disable this behavior, run Sidekick with the `--no-fallback-404` flag.
+
+```bash
+./sidekick serve --no-fallback-404
+```
 
 ### Failover
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,6 +46,7 @@ func initServerFlags(cmd *cobra.Command) {
 	cmd.Flags().String("crunch-traffic-split", "objectkeyhash", "Specify the crunch traffic split strategy: random or objectkeyhash")
 	cmd.Flags().StringP("cloud-platform", "", "", "Cloud platform to use. one of: aws, gcp")
 	cmd.Flags().BoolP("gcp-replicas", "", false, "Whether to query Quicksilver for replica IPs in GCP mode or use the public Bolt endpoint.")
+	cmd.Flags().Bool("no-fallback-404", false, "Disable fallback on 404 response code from AWS request to Bolt or vice-versa.")
 }
 
 var serveCmd = &cobra.Command{
@@ -153,6 +154,9 @@ func getBoltRouterConfig(cmd *cobra.Command) (boltrouter.Config, error) {
 	}
 	if cmd.Flags().Lookup("gcp-replicas").Changed {
 		boltRouterConfig.GcpReplicasEnabled, _ = cmd.Flags().GetBool("gcp-replicas")
+	}
+	if cmd.Flags().Lookup("no-fallback-404").Changed {
+		boltRouterConfig.NoFallback404, _ = cmd.Flags().GetBool("no-fallback-404")
 	}
 	return boltRouterConfig, nil
 }


### PR DESCRIPTION
# What it Does

* Per request from MiQ implement CLI argument-based control of the failover behavior when Crunch returns a 404
* Currently a 404 response from Crunch will always cause Sidekick failover to S3/GCS.
* After this change, when the `--no-fallback-404` flag is passed, a 404 response from Crunch will not result in a failover to S3/GCS.
* Default behavior remains unchanged.
