### PR TITLE
feat: Apache NiFi integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,20 @@ go run main serve
 
 ### GCP Read Replicas
 
-Granica Crunch deployments in GCP can run in a single public endpoint mode (legacy) and regular read-replica mode. In order
-to enable GCP read-replica support, pass the `gcp-replicas` flag to Sidekick.
+Granica Crunch deployments in GCP can run in a single public endpoint mode (legacy) and regular read-replica mode. In order to enable GCP read-replica support, pass the `gcp-replicas` flag to Sidekick.
 
 ```bash
 ./sidekick serve --gcp-replicas
+```
+
+### (AWS) Ignoring region in the Authorization header
+
+Some AWS SDKs default to signing requests for `us-east-1`, which may not always be appropriate. In order to instruct Sidekick to ignore the region specified in the Authorization header and to use the region of the underlying EC2/Google Compute Engine instance, or the `GRANICA_REGION` environment variable, pass the `--aws-ignore-auth-header-region` to Sidekick.
+
+This is only used when running in AWS mode.
+
+```bash
+./sidekick serve --aws-ignore-auth-header-region
 ```
 
 ### Local

--- a/api/api.go
+++ b/api/api.go
@@ -57,6 +57,10 @@ func (a *Api) routeBase(w http.ResponseWriter, req *http.Request) {
 
 	boltReq, err := sess.br.NewBoltRequest(ctx, sess.Logger(), req.Clone(ctx))
 	if err != nil {
+		if strings.Contains(err.Error(), "no auth header in request") {
+			a.BadRequest(sess.Logger(), w, err)
+			return
+		}
 		a.InternalError(sess.Logger(), w, err)
 		return
 	}

--- a/api/error.go
+++ b/api/error.go
@@ -10,3 +10,8 @@ func (a *Api) InternalError(logger *zap.Logger, w http.ResponseWriter, err error
 	logger.Error("internal error", zap.Error(err))
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }
+
+func (a *Api) BadRequest(logger *zap.Logger, w http.ResponseWriter, err error) {
+	logger.Error("bad request", zap.Error(err))
+	http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+}

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -60,7 +60,7 @@ func (br *BoltRouter) NewBoltRequest(ctx context.Context, logger *zap.Logger, re
 }
 
 func (br *BoltRouter) newBoltRequestForAws(ctx context.Context, logger *zap.Logger, req *http.Request) (*BoltRequest, error) {
-	sourceBucket, err := extractSourceBucket(logger, req, br.boltVars.Region.Get())
+	sourceBucket, err := extractSourceBucket(logger, req, br.boltVars.Region.Get(), br.config.AwsIgnoreAuthHeaderRegion)
 	if err != nil {
 		return nil, fmt.Errorf("could not extract source bucket: %w", err)
 	}

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -64,6 +64,7 @@ func (br *BoltRouter) newBoltRequestForAws(ctx context.Context, logger *zap.Logg
 	if err != nil {
 		return nil, fmt.Errorf("could not extract source bucket: %w", err)
 	}
+	logger.Debug("extracted source bucket", zap.String("bucket", sourceBucket.Bucket), zap.String("region", sourceBucket.Region))
 
 	awsCred, err := getAwsCredentialsFromRegion(ctx, sourceBucket.Region)
 	if err != nil {

--- a/boltrouter/bolt_request.go
+++ b/boltrouter/bolt_request.go
@@ -64,7 +64,6 @@ func (br *BoltRouter) newBoltRequestForAws(ctx context.Context, logger *zap.Logg
 	if err != nil {
 		return nil, fmt.Errorf("could not extract source bucket: %w", err)
 	}
-	logger.Debug("extracted source bucket", zap.String("bucket", sourceBucket.Bucket), zap.String("region", sourceBucket.Region))
 
 	awsCred, err := getAwsCredentialsFromRegion(ctx, sourceBucket.Region)
 	if err != nil {

--- a/boltrouter/config.go
+++ b/boltrouter/config.go
@@ -58,12 +58,13 @@ type Config struct {
 }
 
 var DefaultConfig = Config{
-	Local:                false,
-	CloudPlatform:        UndefinedCloudPlatform,
-	Passthrough:          false,
-	Failover:             false,
-	NoFallback404:        false,
-	BoltEndpointOverride: "",
-	CrunchTrafficSplit:   CrunchTrafficSplitByObjectKeyHash,
-	GcpReplicasEnabled:   false,
+	Local:                     false,
+	CloudPlatform:             UndefinedCloudPlatform,
+	Passthrough:               false,
+	Failover:                  false,
+	NoFallback404:             false,
+	BoltEndpointOverride:      "",
+	CrunchTrafficSplit:        CrunchTrafficSplitByObjectKeyHash,
+	GcpReplicasEnabled:        false,
+	AwsIgnoreAuthHeaderRegion: false,
 }

--- a/boltrouter/config.go
+++ b/boltrouter/config.go
@@ -53,6 +53,8 @@ type Config struct {
 
 	// Whether a GCP deployment is single endpoint or we have replicas to take advantage of.
 	GcpReplicasEnabled bool `yaml:"GcpReplicasEnabled"`
+
+	AwsIgnoreAuthHeaderRegion bool `yaml:"AwsIgnoreAuthHeaderRegion"`
 }
 
 var DefaultConfig = Config{

--- a/boltrouter/source_bucket.go
+++ b/boltrouter/source_bucket.go
@@ -28,13 +28,15 @@ type SourceBucket struct {
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 // This method will "n-auth-dummy" if nothing is found
 func extractSourceBucket(logger *zap.Logger, req *http.Request, defaultRegionFallback string, ignoreAuthHeaderRegion bool) (SourceBucket, error) {
-	region := ""
+	var region string
+	var getRegionErr error
+
 	if ignoreAuthHeaderRegion {
 		region = defaultRegionFallback
 	} else {
-		region, err := getRegionForBucket(req.Header.Get("Authorization"))
-		if err != nil {
-			return SourceBucket{}, fmt.Errorf("could not get region for bucket: %w", err)
+		region, getRegionErr = getRegionForBucket(req.Header.Get("Authorization"))
+		if getRegionErr != nil {
+			return SourceBucket{}, fmt.Errorf("could not get region for bucket: %w", getRegionErr)
 		}
 		if region == "" {
 			logger.Warn("could not get region from auth header, using default region fallback", zap.String("defaultRegionFallback", defaultRegionFallback))

--- a/boltrouter/source_bucket_test.go
+++ b/boltrouter/source_bucket_test.go
@@ -36,7 +36,7 @@ func TestExtractSourceBucket(t *testing.T) {
 			})
 
 			req := testS3Client.GetRequest(t, ctx)
-			sourceBucket, err := extractSourceBucket(logger, req, "foo")
+			sourceBucket, err := extractSourceBucket(logger, req, "foo", false)
 			assert.NoError(t, err)
 			assert.Equal(t, bucketName, sourceBucket.Bucket)
 			assert.Equal(t, tc.requestStyle, sourceBucket.Style)
@@ -54,7 +54,24 @@ func TestExtractSourceBucket(t *testing.T) {
 		})
 
 		req := testS3Client.GetRequest(t, ctx)
-		sourceBucket, err := extractSourceBucket(logger, req, "foo")
+		sourceBucket, err := extractSourceBucket(logger, req, "foo", false)
+		assert.NoError(t, err)
+		assert.Equal(t, bucketName, sourceBucket.Bucket)
+		assert.Equal(t, pathStyle, sourceBucket.Style)
+		assert.Equal(t, "foo", sourceBucket.Region)
+	})
+
+	t.Run("IgnoreAuthHeaderRegion", func(t *testing.T) {
+		bucketName := randomdata.SillyName()
+
+		testS3Client := NewTestS3Client(t, ctx, pathStyle, "us-west-1")
+		// This populates testS3Client.req
+		testS3Client.S3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket: aws.String(bucketName),
+		})
+
+		req := testS3Client.GetRequest(t, ctx)
+		sourceBucket, err := extractSourceBucket(logger, req, "foo", true)
 		assert.NoError(t, err)
 		assert.Equal(t, bucketName, sourceBucket.Bucket)
 		assert.Equal(t, pathStyle, sourceBucket.Style)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,6 +47,7 @@ func initServerFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("cloud-platform", "", "", "Cloud platform to use. one of: aws, gcp")
 	cmd.Flags().BoolP("gcp-replicas", "", false, "Whether to query Quicksilver for replica IPs in GCP mode or use the public Bolt endpoint.")
 	cmd.Flags().Bool("no-fallback-404", false, "Disable fallback on 404 response code from AWS request to Bolt or vice-versa.")
+	cmd.Flags().Bool("aws-ignore-auth-header-region", false, "Do not infer region from auth header and use the region specified via GRANICA_REGION env var instead. Only used in AWS mode.")
 }
 
 var serveCmd = &cobra.Command{
@@ -157,6 +158,9 @@ func getBoltRouterConfig(cmd *cobra.Command) (boltrouter.Config, error) {
 	}
 	if cmd.Flags().Lookup("no-fallback-404").Changed {
 		boltRouterConfig.NoFallback404, _ = cmd.Flags().GetBool("no-fallback-404")
+	}
+	if cmd.Flags().Lookup("aws-ignore-auth-header-region").Changed {
+		boltRouterConfig.AwsIgnoreAuthHeaderRegion, _ = cmd.Flags().GetBool("aws-ignore-auth-header-region")
 	}
 	return boltRouterConfig, nil
 }

--- a/integrations/apache-nifi/README.md
+++ b/integrations/apache-nifi/README.md
@@ -1,8 +1,6 @@
 # Apache NiFi integration
 
-You can integrate Sidekick with Apache NiFi by overriding the endpoint URL in the `*S3` processors.
-
-This has been validated only against Granica Crunch running in AWS but Granica Crunch in GCP should work as well.
+Integrate Apache NiFi with Sidekick by overriding the endpoint URL in the `*S3` processors. This integration has been validated with Granica Crunch running in AWS. It should also work with Granica Crunch in GCP.
 
 ## VPC Peering
 
@@ -12,16 +10,16 @@ You need to allow vpc peering from your application vpc to the Granica vpc. You 
 
 ### Sidekick
 
-In order for Sidekick to work with Apache NiFi you need to run it with the `--aws-ignore-auth-header-region` flag.
+To ensure compatibility with Apache NiFi, run Sidekick with the --aws-ignore-auth-header-region flag.
 
-If not running on an ec2 or google compute engine instance in the same region as the Granica Crunch cluster, you'll also need to set the `GRANICA_REGION` environment variable to the region of the Granica Crunch cluster.
+If you're not running on an EC2 or Google Compute Engine instance in the same region as the Granica Crunch cluster, set the GRANICA_REGION environment variable to the Granica Crunch cluster's region.
 
-When running with the endpoint URL override, the underlying AWS SDKs that Apache NiFi uses sign requests targeted at `us-east-1`, however, this is not always desired. Using the `--aws-ignore-auth-header-region` flag will prevent Sidekick from inferring the bucket region from the `Authorization` header and instead cause it to use the region of the underlying ec2/google compute engine instance or the value of the `GRANICA_REGION` environment variable.
+The --aws-ignore-auth-header-region flag is crucial when using endpoint URL overrides. Without it, the AWS SDKs used by Apache NiFi default to signing requests for us-east-1, which may not always be appropriate. This flag instructs Sidekick to ignore the region specified in the Authorization header and to use the region of the underlying EC2/Google Compute Engine instance, or the GRANICA_REGION environment variable, instead.
 
 ### Apache NiFi Processors
 
-Set the `Endpoint Override URL` property to the Sidekick address. This is usually `http://localhost:7075`.
+Configure the Endpoint Override URL property in your Apache NiFi processors to point to the Sidekick address, typically http://localhost:7075.
 
 ## Limitations
 
-When running Sidekick with the `--aws-ignore-auth-header-region` flag accessing buckets in regions different than the Granica Crunch region is not possible.
+Be aware that when running Sidekick with the --aws-ignore-auth-header-region flag, accessing buckets in regions different from the Granica Crunch region is not supported.

--- a/integrations/apache-nifi/README.md
+++ b/integrations/apache-nifi/README.md
@@ -1,0 +1,27 @@
+# Apache NiFi integration
+
+You can integrate Sidekick with Apache NiFi by overriding the endpoint URL in the `*S3` processors.
+
+This has been validated only against Granica Crunch running in AWS but Granica Crunch in GCP should work as well.
+
+## VPC Peering
+
+You need to allow vpc peering from your application vpc to the Granica vpc. You can follow the tutorial [here](https://granica.ai/docs/vpc-peering/) to do so.
+
+## Configuration
+
+### Sidekick
+
+In order for Sidekick to work with Apache NiFi you need to run it with the `--aws-ignore-auth-header-region` flag.
+
+If not running on an ec2 or google compute engine instance in the same region as the Granica Crunch cluster, you'll also need to set the `GRANICA_REGION` environment variable to the region of the Granica Crunch cluster.
+
+When running with the endpoint URL override, the underlying AWS SDKs that Apache NiFi uses sign requests targeted at `us-east-1`, however, this is not always desired. Using the `--aws-ignore-auth-header-region` flag will prevent Sidekick from inferring the bucket region from the `Authorization` header and instead cause it to use the region of the underlying ec2/google compute engine instance or the value of the `GRANICA_REGION` environment variable.
+
+### Apache NiFi Processors
+
+Set the `Endpoint Override URL` properly to the Sidekick address. This is usually `http://localhost:7075`.
+
+## Limitations
+
+When running Sidekick with the `--aws-ignore-auth-header-region` flag accessing buckets in regions different than the Granica Crunch region is not possible.

--- a/integrations/apache-nifi/README.md
+++ b/integrations/apache-nifi/README.md
@@ -20,7 +20,7 @@ When running with the endpoint URL override, the underlying AWS SDKs that Apache
 
 ### Apache NiFi Processors
 
-Set the `Endpoint Override URL` properly to the Sidekick address. This is usually `http://localhost:7075`.
+Set the `Endpoint Override URL` property to the Sidekick address. This is usually `http://localhost:7075`.
 
 ## Limitations
 

--- a/integrations/apache-nifi/README.md
+++ b/integrations/apache-nifi/README.md
@@ -10,16 +10,16 @@ You need to allow vpc peering from your application vpc to the Granica vpc. You 
 
 ### Sidekick
 
-To ensure compatibility with Apache NiFi, run Sidekick with the --aws-ignore-auth-header-region flag.
+To ensure compatibility with Apache NiFi, run Sidekick with the `--aws-ignore-auth-header-region` flag.
 
-If you're not running on an EC2 or Google Compute Engine instance in the same region as the Granica Crunch cluster, set the GRANICA_REGION environment variable to the Granica Crunch cluster's region.
+If you're not running on an EC2 or Google Compute Engine instance in the same region as the Granica Crunch cluster, set the `GRANICA_REGION` environment variable to the Granica Crunch cluster's region.
 
-The --aws-ignore-auth-header-region flag is crucial when using endpoint URL overrides. Without it, the AWS SDKs used by Apache NiFi default to signing requests for us-east-1, which may not always be appropriate. This flag instructs Sidekick to ignore the region specified in the Authorization header and to use the region of the underlying EC2/Google Compute Engine instance, or the GRANICA_REGION environment variable, instead.
+The `--aws-ignore-auth-header-region` flag is crucial when using endpoint URL overrides. Without it, the AWS SDKs used by Apache NiFi default to signing requests for `us-east-1`, which may not always be appropriate. This flag instructs Sidekick to ignore the region specified in the Authorization header and to use the region of the underlying EC2/Google Compute Engine instance, or the `GRANICA_REGION` environment variable, instead.
 
 ### Apache NiFi Processors
 
-Configure the Endpoint Override URL property in your Apache NiFi processors to point to the Sidekick address, typically http://localhost:7075.
+Configure the Endpoint Override URL property in your Apache NiFi processors to point to the Sidekick address, typically `http://localhost:7075`.
 
 ## Limitations
 
-Be aware that when running Sidekick with the --aws-ignore-auth-header-region flag, accessing buckets in regions different from the Granica Crunch region is not supported.
+Be aware that when running Sidekick with the `--aws-ignore-auth-header-region` flag, accessing buckets in regions different from the Granica Crunch region is not supported.


### PR DESCRIPTION
# What it Does

* Add the `aws-ignore-auth-header-region` flag to `serve` command
* Add the matching field to Bolt router config
* If the above field is true set bucket region to the region from bolt vars instead of inferring from the `Credential` part of the `Authorization` header.
* Add a bad request helper function and return bad request if request incoming to Sidekick does not have an authorization header, instead of returning a 500.
* Add apache nifi integration docs

# Why

This change is motivated by the integration with Apache NiFi. When NiFi `*S3` processors make a request to Sidekick the `Authorization` header of the incoming request looks like

```
Authorization: AWS4-HMAC-SHA256 Credential=AKIA5M5ADDSG4RWJDKUS/20231128/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;amz-sdk-retry;content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=9734a673ce1febada676904f1006c315737b3e451f570ca4dfea0167ab6c0ab3
```

The interesting part here is `Credential` which we use to deduce the region to use when creating requests going to Crunch and AWS. Despite configuring the regions in each processor (and some under the hood NiFi configs), the Credential part looks like

```
AKIA5M5ADDSG4RWJDKUS/20231128/us-east-1/s3/aws4_request
```

and the inferred region is `us-east-1` while the bucket actually resides in `us-west-2`.

After this change, we're able to force the region specified via the `GRANICA_REGION` env var explicitly and get NiFi working

<!-- Does it add a new feature? Does it fix a bug? -->
