### PR TITLE
feat: added resp content len in log

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -44,6 +44,7 @@ func (api *Api) routeBase(w http.ResponseWriter, req *http.Request) {
 	sess.WithLogger(sess.Logger().With(
 		zap.Int("awsStatusCode", resp.StatusCode),
 		zap.Bool("crunched", crunched),
+		zap.Int("respContentLength", int(resp.ContentLength)),
 	))
 
 	// Convert the response headers to lower case, as Python etc libraries expect lower case.


### PR DESCRIPTION
<!-- PR title should follow conventional commits[] -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

# What it Does

added `respContentLength` in log struct

<!-- Does it add a new feature? Does it fix a bug? -->
